### PR TITLE
Add migration hook

### DIFF
--- a/charts/spicedb/Chart.yaml
+++ b/charts/spicedb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: spicedb
 description: A Helm chart to manage a Kubernetes based deployment of Authzed spicedb. For more information see https://github.com/authzed/spicedb.
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: "v1.4.0"

--- a/charts/spicedb/templates/migration.yaml
+++ b/charts/spicedb/templates/migration.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "spicedb.fullname" . }}
+  labels:
+    {{- include "spicedb.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  template:
+    metadata:
+      name: {{ include "spicedb.fullname" . }}
+      labels:
+        {{- include "spicedb.labels" . | nindent 4 }}
+    spec:
+      restartyPolicy: Never 
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml. | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: ["/bin/sh", "-c", "/opt/spicedb migrate head --datastore-engine={{ .Values.datastore.engine }} --datastore-conn-uri=\"{{ .Values.datastore.connection.uri }}\""]
+          envFrom: 
+            - secretRef:
+                name: {{ include "spicedb.fullname" . }}

--- a/charts/spicedb/templates/migration.yaml
+++ b/charts/spicedb/templates/migration.yaml
@@ -22,7 +22,14 @@ spec:
       containers:
         - name: migrate
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: ["/bin/sh", "-c", "/opt/spicedb migrate head --datastore-engine={{ .Values.datastore.engine }} --datastore-conn-uri=\"{{ .Values.datastore.connection.uri }}\""]
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - migrate
+            - head
+            - --datastore-engine={{ .Values.datastore.engine }}
+            {{- if and (ne .Values.datastore.engine "memory") (not .Values.datastore.connection.uriSecretName) }}
+            - --datastore-conn-uri={{ .Values.datastore.connection.uri }}
+            {{- end }}
           envFrom: 
             - secretRef:
                 name: {{ include "spicedb.fullname" . }}


### PR DESCRIPTION
Add migration hook such that every time the version is bumped, a migration is run on the database. Taken from [here](https://discord.com/channels/844600078504951838/844600078948630559/957991124251836436).

Would love if you could double check my formatting is correct, and that the hook is defined correctly. Hoping that this will avoid downtime when we bump SpiceDB versions!