### PR TITLE
Update/remove deprecated SpiceDB serve flags

### DIFF
--- a/charts/spicedb/Chart.yaml
+++ b/charts/spicedb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: spicedb
 description: A Helm chart to manage a Kubernetes based deployment of Authzed spicedb. For more information see https://github.com/authzed/spicedb.
 type: application
-version: 0.2.12
+version: 0.2.13
 appVersion: "v1.37.1"

--- a/charts/spicedb/templates/deployment.yaml
+++ b/charts/spicedb/templates/deployment.yaml
@@ -63,10 +63,11 @@ spec:
             - --http-enabled={{ .Values.http.enabled }}
             - --dispatch-cluster-enabled={{ .Values.dispatch.enabled }}
             - --metrics-enabled={{ .Values.metrics.enabled }}
-            - --dashboard-enabled={{ .Values.dashboard.enabled }}
             - --datastore-engine={{ .Values.datastore.engine }}
-            - --datastore-conn-max-open={{ .Values.datastore.connection.maxOpenConn }}
-            - --datastore-conn-min-open={{ .Values.datastore.connection.minOpenConn }}
+            - --datastore-conn-pool-read-max-open={{ .Values.datastore.connection.poolReadMaxOpen }}
+            - --datastore-conn-pool-read-min-open={{ .Values.datastore.connection.poolReadMinOpen }}
+            - --datastore-conn-pool-write-max-open={{ .Values.datastore.connection.poolWriteMaxOpen }}
+            - --datastore-conn-pool-write-min-open={{ .Values.datastore.connection.poolWriteMinOpen }}
             - --grpc-shutdown-grace-period={{ .Values.grpc.shutdownGracePeriod }}
 
             {{- if .Values.datastore.awsIam.enabled }}

--- a/charts/spicedb/values.yaml
+++ b/charts/spicedb/values.yaml
@@ -6,10 +6,6 @@ service:
     ### Required (if dispatch.tls.enabled)
     secretName:
 
-dashboard:
-  enabled: true
-  port: 8080
-
 datastore:
   engine: memory
   awsIam:
@@ -18,8 +14,10 @@ datastore:
     ### Define either uri or uriSecretName but not both
     uri:
     uriSecretName:
-    maxOpenConn: 50
-    minOpenConn: 10
+    poolReadMaxOpen: 20
+    poolReadMinOpen: 20
+    poolWriteMaxOpen: 10
+    poolWriteMinOpen: 10
   gc:
     interval: 3m0s
     maxOperationTime: 1m0s
@@ -54,10 +52,6 @@ metrics:
 
 watch:
   heartbeat:
-
-  # disable-v1-schema-api
-  # ns-cache-expiration
-  # schema-prefixes-required
 
 replicas: 3
 


### PR DESCRIPTION
* Remove `--dashboard-enabled`
* Replace `--datastore-conn-max-open` and `--datastore-conn-min-open` with
  * `--datastore-conn-pool-read-max-open`
  * `--datastore-conn-pool-read-min-open`
  * `--datastore-conn-pool-write-max-open`
  * `--datastore-conn-pool-write-min-open`
* Set the defaults to the SpiceDB defaults for the 4 new flags